### PR TITLE
Add responsive project manager portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Project-Management-Portfolio
+# Project Management Portfolio
+
+A simple responsive portfolio website for a project manager.
+
+## Getting Started
+
+Open `index.html` in a browser to view the site.
+
+## Structure
+
+- `index.html` – main page markup
+- `styles.css` – site styles
+- `script.js` – navigation toggle logic
+
+## Deploying to GitHub Pages
+
+Push the site files to your repository and enable **GitHub Pages** in the
+repository settings. Selecting the branch that contains `index.html` will serve
+the portfolio instead of the default README view.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Portfolio of project manager Alex Morgan">
+    <title>Project Manager Portfolio</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Alex Morgan</h1>
+            <nav id="nav">
+                <button id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+                <ul id="nav-list">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <section class="hero">
+        <div class="container">
+            <h2>Project Management Portfolio</h2>
+            <p>Delivering projects on time, on budget, and on target.</p>
+        </div>
+    </section>
+
+    <section id="about" class="about">
+        <div class="container">
+            <h2>About Me</h2>
+            <p>Experienced project manager with a passion for guiding teams to success. Skilled in agile methodologies and cross-functional collaboration.</p>
+        </div>
+    </section>
+
+    <section id="projects" class="projects">
+        <div class="container">
+            <h2>Projects</h2>
+            <div class="grid">
+                <div class="card">
+                    <h3>Website Redesign</h3>
+                    <p>Led a complete redesign of corporate website, improving user engagement by 40%.</p>
+                </div>
+                <div class="card">
+                    <h3>Product Launch</h3>
+                    <p>Coordinated cross-departmental teams to launch a new product line ahead of schedule.</p>
+                </div>
+                <div class="card">
+                    <h3>Process Optimization</h3>
+                    <p>Implemented new workflow tools that reduced overhead costs by 15%.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="contact" class="contact">
+        <div class="container">
+            <h2>Contact</h2>
+            <form>
+                <input type="text" placeholder="Name" required>
+                <input type="email" placeholder="Email" required>
+                <textarea placeholder="Message" required></textarea>
+                <button type="submit">Send</button>
+            </form>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2024 Alex Morgan</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,8 @@
+const navToggle = document.getElementById('nav-toggle');
+const navList = document.getElementById('nav-list');
+
+navToggle.addEventListener('click', () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+    navList.classList.toggle('open');
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,119 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    line-height: 1.6;
+}
+
+header {
+    background: #333;
+    color: #fff;
+}
+
+header .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+}
+
+#nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+#nav a {
+    color: #fff;
+    text-decoration: none;
+}
+
+#nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.hero {
+    background: #f4f4f4;
+    text-align: center;
+    padding: 4rem 1rem;
+}
+
+section {
+    padding: 2rem 1rem;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.projects .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background: #fff;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+input, textarea {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    padding: 0.75rem;
+    border: none;
+    background: #333;
+    color: #fff;
+    cursor: pointer;
+}
+
+footer {
+    background: #333;
+    color: #fff;
+    text-align: center;
+    padding: 1rem;
+}
+
+@media (max-width: 768px) {
+    #nav ul {
+        flex-direction: column;
+        display: none;
+        background: #333;
+        position: absolute;
+        top: 60px;
+        right: 10px;
+        width: 200px;
+        padding: 1rem;
+    }
+
+    #nav ul.open {
+        display: flex;
+    }
+
+    #nav-toggle {
+        display: block;
+    }
+}


### PR DESCRIPTION
## Summary
- add single-page portfolio site with about, project gallery, and contact sections
- style layout for desktop and mobile with flexbox, grid, and responsive navigation
- include small script for toggling mobile menu and update README
- improve navigation accessibility with `aria-expanded` and document deployment steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68904d41bdb4833191952525c05299d4