### PR TITLE
Add responsive project manager portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ Open `index.html` in a browser to view the site.
 
 - `index.html` – main page markup with hero, about, services, projects, and contact sections
 - `styles.css` – site styles including responsive layout and navigation
-- `script.js` – navigation toggle logic for mobile
+- `script.js` – navigation toggle logic and scroll-triggered animations
 
 ## Deploying to GitHub Pages
 
 Push the site files to your repository and enable **GitHub Pages** in the
 repository settings. Selecting the branch that contains `index.html` will serve
 the portfolio instead of the default README view.
+
+## Customization
+
+- Replace "Your Name" in `index.html` with your own name and update the About section text.
+- Update the contact info block in `index.html` with your email and phone number.
+- Adjust project and service descriptions to reflect your experience.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Project Management Portfolio
 
-A simple responsive portfolio website for a project manager.
+A responsive portfolio website for a project manager, featuring sections for
+about, services, selected projects, and a contact form.
 
 ## Getting Started
 
@@ -8,9 +9,9 @@ Open `index.html` in a browser to view the site.
 
 ## Structure
 
-- `index.html` – main page markup
-- `styles.css` – site styles
-- `script.js` – navigation toggle logic
+- `index.html` – main page markup with hero, about, services, projects, and contact sections
+- `styles.css` – site styles including responsive layout and navigation
+- `script.js` – navigation toggle logic for mobile
 
 ## Deploying to GitHub Pages
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Open `index.html` in a browser to view the site.
 
 - `index.html` – main page markup with hero, about, services, projects, and contact sections
 - `styles.css` – site styles including responsive layout and navigation
-- `script.js` – navigation toggle logic and scroll-triggered animations
+- `script.js` – navigation toggle logic, scroll-triggered animations, and email handler for the contact form
 
 ## Deploying to GitHub Pages
 
@@ -22,4 +22,6 @@ the portfolio instead of the default README view.
 ## Customization
 
 If you fork this repository, update the name and contact info in `index.html`
-and adjust project and service descriptions to match your experience.
+and adjust project and service descriptions to match your experience. The
+contact form sends a `mailto` email to `natnaelamare1314@gmail.com`; change the
+address in `script.js` if you want submissions delivered elsewhere.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A responsive portfolio website for project manager **Natnael Bedilu**, featuring a
 split hero with photo and overview, services, selected projects, and a contact form.
+Smooth scrolling, hover animations, and an active navigation highlight make the
+page feel lively and interactive on every device.
 
 ## Getting Started
 
@@ -11,7 +13,7 @@ Open `index.html` in a browser to view the site.
 
 - `index.html` – main page markup with split hero, services, projects, and contact sections
 - `styles.css` – site styles including responsive layout and navigation
-- `script.js` – navigation toggle logic, scroll-triggered animations, email handler for the contact form, and theme switch
+- `script.js` – navigation toggle logic, active link highlighting, scroll-triggered animations, email handler for the contact form, and theme switch
 
 ## Deploying to GitHub Pages
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Project Management Portfolio
 
-A responsive portfolio website for a project manager, featuring sections for
-about, services, selected projects, and a contact form.
+A responsive portfolio website for project manager **Natnael Bedilu**, featuring
+sections for about, services, selected projects, and a contact form.
 
 ## Getting Started
 
@@ -21,6 +21,5 @@ the portfolio instead of the default README view.
 
 ## Customization
 
-- Replace "Your Name" in `index.html` with your own name and update the About section text.
-- Update the contact info block in `index.html` with your email and phone number.
-- Adjust project and service descriptions to reflect your experience.
+If you fork this repository, update the name and contact info in `index.html`
+and adjust project and service descriptions to match your experience.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Project-Management-Portfolio
+# Project Management Portfolio
+
+A simple responsive portfolio website for a project manager.
+
+## Getting Started
+
+Open `index.html` in a browser to view the site.
+
+## Structure
+
+- `index.html` – main page markup
+- `styles.css` – site styles
+- `script.js` – navigation toggle logic
+
+## Deploying to GitHub Pages
+
+Push the site files to your repository and enable **GitHub Pages** in the
+repository settings. Selecting the branch that contains `index.html` will serve
+the portfolio instead of the default README view.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Open `index.html` in a browser to view the site.
 
 - `index.html` – main page markup with hero, about, services, projects, and contact sections
 - `styles.css` – site styles including responsive layout and navigation
-- `script.js` – navigation toggle logic, scroll-triggered animations, and email handler for the contact form
+- `script.js` – navigation toggle logic, scroll-triggered animations, email handler for the contact form, and theme switch
 
 ## Deploying to GitHub Pages
 
@@ -24,4 +24,6 @@ the portfolio instead of the default README view.
 If you fork this repository, update the name and contact info in `index.html`
 and adjust project and service descriptions to match your experience. The
 contact form sends a `mailto` email to `natnaelamare1314@gmail.com`; change the
-address in `script.js` if you want submissions delivered elsewhere.
+address in `script.js` if you want submissions delivered elsewhere. Use the
+theme switch in the navigation menu to toggle light and dark modes; your
+selection is saved in local storage.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Project Management Portfolio
 
-A responsive portfolio website for project manager **Natnael Bedilu**, featuring
-sections for about, services, selected projects, and a contact form.
+A responsive portfolio website for project manager **Natnael Bedilu**, featuring a
+split hero with photo and overview, services, selected projects, and a contact form.
 
 ## Getting Started
 
@@ -9,7 +9,7 @@ Open `index.html` in a browser to view the site.
 
 ## Structure
 
-- `index.html` – main page markup with hero, about, services, projects, and contact sections
+- `index.html` – main page markup with split hero, services, projects, and contact sections
 - `styles.css` – site styles including responsive layout and navigation
 - `script.js` – navigation toggle logic, scroll-triggered animations, email handler for the contact form, and theme switch
 

--- a/index.html
+++ b/index.html
@@ -1,79 +1,107 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Portfolio of project manager Alex Morgan">
-    <title>Project Manager Portfolio</title>
-    <link rel="stylesheet" href="styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Portfolio site for project manager Alex Morgan" />
+  <title>Alex Morgan | Project Manager</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="container">
-            <h1>Alex Morgan</h1>
-            <nav id="nav">
-                <button id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
-                <ul id="nav-list">
-                    <li><a href="#about">About</a></li>
-                    <li><a href="#projects">Projects</a></li>
-                    <li><a href="#contact">Contact</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
+  <header class="site-header">
+    <div class="container">
+      <a href="#" class="logo">Alex Morgan</a>
+      <nav id="nav">
+        <button id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+        <ul id="nav-list">
+          <li><a href="#about">About</a></li>
+          <li><a href="#services">Services</a></li>
+          <li><a href="#projects">Projects</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-    <section class="hero">
-        <div class="container">
-            <h2>Project Management Portfolio</h2>
-            <p>Delivering projects on time, on budget, and on target.</p>
-        </div>
-    </section>
+  <section class="hero">
+    <div class="container">
+      <h1>Delivering results through strategic project leadership</h1>
+      <p>Guiding teams from concept to completion with clarity and purpose.</p>
+      <a href="#contact" class="btn">Let's Work Together</a>
+    </div>
+  </section>
 
-    <section id="about" class="about">
-        <div class="container">
-            <h2>About Me</h2>
-            <p>Experienced project manager with a passion for guiding teams to success. Skilled in agile methodologies and cross-functional collaboration.</p>
-        </div>
-    </section>
+  <section id="about" class="about">
+    <div class="container">
+      <div class="about-text">
+        <h2>About Me</h2>
+        <p>I'm a certified project manager with over eight years of experience overseeing complex initiatives across technology, marketing, and operations. I believe in transparent communication, data-driven planning, and empowering teams to do their best work.</p>
+      </div>
+      <div class="about-image"></div>
+    </div>
+  </section>
 
-    <section id="projects" class="projects">
-        <div class="container">
-            <h2>Projects</h2>
-            <div class="grid">
-                <div class="card">
-                    <h3>Website Redesign</h3>
-                    <p>Led a complete redesign of corporate website, improving user engagement by 40%.</p>
-                </div>
-                <div class="card">
-                    <h3>Product Launch</h3>
-                    <p>Coordinated cross-departmental teams to launch a new product line ahead of schedule.</p>
-                </div>
-                <div class="card">
-                    <h3>Process Optimization</h3>
-                    <p>Implemented new workflow tools that reduced overhead costs by 15%.</p>
-                </div>
-            </div>
+  <section id="services" class="services">
+    <div class="container">
+      <h2>Services</h2>
+      <div class="grid">
+        <div class="service">
+          <h3>Project Planning</h3>
+          <p>Scope definition, milestones, and budgeting to set your project up for success.</p>
         </div>
-    </section>
-
-    <section id="contact" class="contact">
-        <div class="container">
-            <h2>Contact</h2>
-            <form>
-                <input type="text" placeholder="Name" required>
-                <input type="email" placeholder="Email" required>
-                <textarea placeholder="Message" required></textarea>
-                <button type="submit">Send</button>
-            </form>
+        <div class="service">
+          <h3>Team Leadership</h3>
+          <p>Motivating and aligning cross‑functional teams toward shared objectives.</p>
         </div>
-    </section>
-
-    <footer>
-        <div class="container">
-            <p>&copy; 2024 Alex Morgan</p>
+        <div class="service">
+          <h3>Risk Management</h3>
+          <p>Identifying and mitigating potential blockers before they impact delivery.</p>
         </div>
-    </footer>
+      </div>
+    </div>
+  </section>
 
-    <script src="script.js"></script>
+  <section id="projects" class="projects">
+    <div class="container">
+      <h2>Selected Projects</h2>
+      <div class="grid">
+        <div class="project-card">
+          <div class="project-image project1"></div>
+          <h3>Enterprise Resource Planning Rollout</h3>
+          <p>Coordinated a global ERP deployment across six countries on schedule and within budget.</p>
+        </div>
+        <div class="project-card">
+          <div class="project-image project2"></div>
+          <h3>Marketing Automation Platform</h3>
+          <p>Led cross‑departmental teams to launch a platform that increased lead generation by 30%.</p>
+        </div>
+        <div class="project-card">
+          <div class="project-image project3"></div>
+          <h3>Customer Support Revamp</h3>
+          <p>Oversaw implementation of a new support workflow, reducing response times by 40%.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="contact" class="contact">
+    <div class="container">
+      <h2>Contact</h2>
+      <form>
+        <input type="text" placeholder="Name" required />
+        <input type="email" placeholder="Email" required />
+        <textarea placeholder="Message" required></textarea>
+        <button type="submit">Send Message</button>
+      </form>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2024 Alex Morgan</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,14 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Portfolio site for project manager Alex Morgan" />
-  <title>Alex Morgan | Project Manager</title>
+  <meta name="description" content="Portfolio site for project manager" />
+  <title>Your Name | Project Manager</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
     <div class="container">
-      <a href="#" class="logo">Alex Morgan</a>
+      <a href="#" class="logo">Your Name</a>
       <nav id="nav">
         <button id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
         <ul id="nav-list">
@@ -25,35 +26,35 @@
 
   <section class="hero">
     <div class="container">
-      <h1>Delivering results through strategic project leadership</h1>
-      <p>Guiding teams from concept to completion with clarity and purpose.</p>
-      <a href="#contact" class="btn">Let's Work Together</a>
+      <h1 class="fade-up">Delivering results through strategic project leadership</h1>
+      <p class="fade-up">Guiding teams from concept to completion with clarity and purpose.</p>
+      <a href="#contact" class="btn fade-up">Let's Work Together</a>
     </div>
   </section>
 
-  <section id="about" class="about">
-    <div class="container">
-      <div class="about-text">
-        <h2>About Me</h2>
-        <p>I'm a certified project manager with over eight years of experience overseeing complex initiatives across technology, marketing, and operations. I believe in transparent communication, data-driven planning, and empowering teams to do their best work.</p>
+    <section id="about" class="about">
+      <div class="container">
+        <div class="about-text fade-up">
+          <h2>About Me</h2>
+          <p>I'm a certified project manager with over eight years of experience overseeing complex initiatives across technology, marketing, and operations. I believe in transparent communication, data-driven planning, and empowering teams to do their best work.</p>
+        </div>
+        <div class="about-image fade-up"></div>
       </div>
-      <div class="about-image"></div>
-    </div>
-  </section>
+    </section>
 
   <section id="services" class="services">
     <div class="container">
       <h2>Services</h2>
       <div class="grid">
-        <div class="service">
+        <div class="service fade-up">
           <h3>Project Planning</h3>
           <p>Scope definition, milestones, and budgeting to set your project up for success.</p>
         </div>
-        <div class="service">
+        <div class="service fade-up">
           <h3>Team Leadership</h3>
           <p>Motivating and aligning cross‑functional teams toward shared objectives.</p>
         </div>
-        <div class="service">
+        <div class="service fade-up">
           <h3>Risk Management</h3>
           <p>Identifying and mitigating potential blockers before they impact delivery.</p>
         </div>
@@ -65,17 +66,17 @@
     <div class="container">
       <h2>Selected Projects</h2>
       <div class="grid">
-        <div class="project-card">
+        <div class="project-card fade-up">
           <div class="project-image project1"></div>
           <h3>Enterprise Resource Planning Rollout</h3>
           <p>Coordinated a global ERP deployment across six countries on schedule and within budget.</p>
         </div>
-        <div class="project-card">
+        <div class="project-card fade-up">
           <div class="project-image project2"></div>
           <h3>Marketing Automation Platform</h3>
           <p>Led cross‑departmental teams to launch a platform that increased lead generation by 30%.</p>
         </div>
-        <div class="project-card">
+        <div class="project-card fade-up">
           <div class="project-image project3"></div>
           <h3>Customer Support Revamp</h3>
           <p>Oversaw implementation of a new support workflow, reducing response times by 40%.</p>
@@ -87,7 +88,11 @@
   <section id="contact" class="contact">
     <div class="container">
       <h2>Contact</h2>
-      <form>
+      <div class="contact-info fade-up">
+        <p>Email: <a href="mailto:you@example.com">you@example.com</a></p>
+        <p>Phone: <a href="tel:+1234567890">+1 (234) 567-890</a></p>
+      </div>
+      <form class="fade-up">
         <input type="text" placeholder="Name" required />
         <input type="email" placeholder="Email" required />
         <textarea placeholder="Message" required></textarea>
@@ -98,7 +103,7 @@
 
   <footer class="site-footer">
     <div class="container">
-      <p>&copy; 2024 Alex Morgan</p>
+      <p>&copy; 2024 Your Name</p>
     </div>
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Portfolio of project manager Alex Morgan">
+    <title>Project Manager Portfolio</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Alex Morgan</h1>
+            <nav id="nav">
+                <button id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+                <ul id="nav-list">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <section class="hero">
+        <div class="container">
+            <h2>Project Management Portfolio</h2>
+            <p>Delivering projects on time, on budget, and on target.</p>
+        </div>
+    </section>
+
+    <section id="about" class="about">
+        <div class="container">
+            <h2>About Me</h2>
+            <p>Experienced project manager with a passion for guiding teams to success. Skilled in agile methodologies and cross-functional collaboration.</p>
+        </div>
+    </section>
+
+    <section id="projects" class="projects">
+        <div class="container">
+            <h2>Projects</h2>
+            <div class="grid">
+                <div class="card">
+                    <h3>Website Redesign</h3>
+                    <p>Led a complete redesign of corporate website, improving user engagement by 40%.</p>
+                </div>
+                <div class="card">
+                    <h3>Product Launch</h3>
+                    <p>Coordinated cross-departmental teams to launch a new product line ahead of schedule.</p>
+                </div>
+                <div class="card">
+                    <h3>Process Optimization</h3>
+                    <p>Implemented new workflow tools that reduced overhead costs by 15%.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="contact" class="contact">
+        <div class="container">
+            <h2>Contact</h2>
+            <form>
+                <input type="text" placeholder="Name" required>
+                <input type="email" placeholder="Email" required>
+                <textarea placeholder="Message" required></textarea>
+                <button type="submit">Send</button>
+            </form>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2024 Alex Morgan</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -93,10 +93,10 @@
         <p>Phone: <a href="tel:+251907796956">+251 907 796 956</a></p>
         <p>LinkedIn: <a href="https://www.linkedin.com/in/natnael-bedilu" target="_blank">linkedin.com/in/natnael-bedilu</a></p>
       </div>
-      <form class="fade-up">
-        <input type="text" placeholder="Name" required />
-        <input type="email" placeholder="Email" required />
-        <textarea placeholder="Message" required></textarea>
+      <form id="contact-form" class="fade-up">
+        <input type="text" name="name" placeholder="Name" required />
+        <input type="email" name="email" placeholder="Email" required />
+        <textarea name="message" placeholder="Message" required></textarea>
         <button type="submit">Send Message</button>
       </form>
     </div>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,13 @@
           <li><a href="#services">Services</a></li>
           <li><a href="#projects">Projects</a></li>
           <li><a href="#contact">Contact</a></li>
+          <li class="theme-switch">
+            <span>Dark mode</span>
+            <label class="switch">
+              <input type="checkbox" id="theme-toggle" />
+              <span class="slider"></span>
+            </label>
+          </li>
         </ul>
       </nav>
     </div>

--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Portfolio site for project manager" />
-  <title>Your Name | Project Manager</title>
+  <meta name="description" content="Portfolio site for project manager Natnael Bedilu" />
+  <title>Natnael Bedilu | Project Manager</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
     <div class="container">
-      <a href="#" class="logo">Your Name</a>
+      <a href="#" class="logo">Natnael Bedilu</a>
       <nav id="nav">
         <button id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
         <ul id="nav-list">
@@ -26,8 +26,8 @@
 
   <section class="hero">
     <div class="container">
-      <h1 class="fade-up">Delivering results through strategic project leadership</h1>
-      <p class="fade-up">Guiding teams from concept to completion with clarity and purpose.</p>
+      <h1 class="fade-up">Natnael Bedilu</h1>
+      <p class="fade-up">Project manager with over 1 year of experience turning ideas into results.</p>
       <a href="#contact" class="btn fade-up">Let's Work Together</a>
     </div>
   </section>
@@ -36,7 +36,7 @@
       <div class="container">
         <div class="about-text fade-up">
           <h2>About Me</h2>
-          <p>I'm a certified project manager with over eight years of experience overseeing complex initiatives across technology, marketing, and operations. I believe in transparent communication, data-driven planning, and empowering teams to do their best work.</p>
+          <p>I'm Natnael Bedilu, a project manager with over a year of experience guiding cross-functional teams. I believe in transparent communication, adaptive planning, and empowering others to deliver their best work.</p>
         </div>
         <div class="about-image fade-up"></div>
       </div>
@@ -89,8 +89,9 @@
     <div class="container">
       <h2>Contact</h2>
       <div class="contact-info fade-up">
-        <p>Email: <a href="mailto:you@example.com">you@example.com</a></p>
-        <p>Phone: <a href="tel:+1234567890">+1 (234) 567-890</a></p>
+        <p>Email: <a href="mailto:natnaelamare1314@gmail.com">natnaelamare1314@gmail.com</a></p>
+        <p>Phone: <a href="tel:+251907796956">+251 907 796 956</a></p>
+        <p>LinkedIn: <a href="https://www.linkedin.com/in/natnael-bedilu" target="_blank">linkedin.com/in/natnael-bedilu</a></p>
       </div>
       <form class="fade-up">
         <input type="text" placeholder="Name" required />
@@ -103,7 +104,7 @@
 
   <footer class="site-footer">
     <div class="container">
-      <p>&copy; 2024 Your Name</p>
+      <p>&copy; 2024 Natnael Bedilu</p>
     </div>
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -31,23 +31,16 @@
     </div>
   </header>
 
-  <section class="hero">
+  <section class="hero" id="about">
     <div class="container">
-      <h1 class="fade-up">Natnael Bedilu</h1>
-      <p class="fade-up">Project manager with over 1 year of experience turning ideas into results.</p>
-      <a href="#contact" class="btn fade-up">Let's Work Together</a>
+      <div class="hero-image fade-up"></div>
+      <div class="hero-text fade-up">
+        <h1>Natnael Bedilu</h1>
+        <p>I'm a project manager with over a year of experience guiding cross‑functional teams. I believe in transparent communication, adaptive planning, and empowering others to deliver their best work.</p>
+        <a href="#contact" class="btn">Let's Work Together</a>
+      </div>
     </div>
   </section>
-
-    <section id="about" class="about">
-      <div class="container">
-        <div class="about-text fade-up">
-          <h2>About Me</h2>
-          <p>I'm Natnael Bedilu, a project manager with over a year of experience guiding cross-functional teams. I believe in transparent communication, adaptive planning, and empowering others to deliver their best work.</p>
-        </div>
-        <div class="about-image fade-up"></div>
-      </div>
-    </section>
 
   <section id="services" class="services">
     <div class="container">

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const navToggle = document.getElementById('nav-toggle');
 const navList = document.getElementById('nav-list');
 const navLinks = document.querySelectorAll('#nav-list a');
+const themeToggle = document.getElementById('theme-toggle');
 
 navToggle.addEventListener('click', () => {
   const expanded = navToggle.getAttribute('aria-expanded') === 'true';
@@ -12,6 +13,20 @@ navLinks.forEach(link => link.addEventListener('click', () => {
   navList.classList.remove('open');
   navToggle.setAttribute('aria-expanded', 'false');
 }));
+
+if (themeToggle) {
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme === 'dark') {
+    document.body.setAttribute('data-theme', 'dark');
+    themeToggle.checked = true;
+  }
+
+  themeToggle.addEventListener('change', () => {
+    const theme = themeToggle.checked ? 'dark' : 'light';
+    document.body.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  });
+}
 
 const animatedElements = document.querySelectorAll('.fade-up');
 

--- a/script.js
+++ b/script.js
@@ -1,0 +1,8 @@
+const navToggle = document.getElementById('nav-toggle');
+const navList = document.getElementById('nav-list');
+
+navToggle.addEventListener('click', () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+    navList.classList.toggle('open');
+});

--- a/script.js
+++ b/script.js
@@ -1,8 +1,14 @@
 const navToggle = document.getElementById('nav-toggle');
 const navList = document.getElementById('nav-list');
+const navLinks = document.querySelectorAll('#nav-list a');
 
 navToggle.addEventListener('click', () => {
-    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-    navToggle.setAttribute('aria-expanded', String(!expanded));
-    navList.classList.toggle('open');
+  const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+  navToggle.setAttribute('aria-expanded', String(!expanded));
+  navList.classList.toggle('open');
 });
+
+navLinks.forEach(link => link.addEventListener('click', () => {
+  navList.classList.remove('open');
+  navToggle.setAttribute('aria-expanded', 'false');
+}));

--- a/script.js
+++ b/script.js
@@ -12,3 +12,16 @@ navLinks.forEach(link => link.addEventListener('click', () => {
   navList.classList.remove('open');
   navToggle.setAttribute('aria-expanded', 'false');
 }));
+
+const animatedElements = document.querySelectorAll('.fade-up');
+
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('in-view');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+animatedElements.forEach(el => observer.observe(el));

--- a/script.js
+++ b/script.js
@@ -25,3 +25,19 @@ const observer = new IntersectionObserver(entries => {
 }, { threshold: 0.1 });
 
 animatedElements.forEach(el => observer.observe(el));
+
+const contactForm = document.getElementById('contact-form');
+
+if (contactForm) {
+  contactForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const form = e.target;
+    const name = form.name.value.trim();
+    const email = form.email.value.trim();
+    const message = form.message.value.trim();
+    const subject = encodeURIComponent(`Portfolio Contact from ${name}`);
+    const body = encodeURIComponent(`Name: ${name}\nEmail: ${email}\n\n${message}`);
+    window.location.href = `mailto:natnaelamare1314@gmail.com?subject=${subject}&body=${body}`;
+    form.reset();
+  });
+}

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const navToggle = document.getElementById('nav-toggle');
 const navList = document.getElementById('nav-list');
 const navLinks = document.querySelectorAll('#nav-list a');
+const sections = document.querySelectorAll('section[id]');
 const themeToggle = document.getElementById('theme-toggle');
 
 navToggle.addEventListener('click', () => {
@@ -13,6 +14,23 @@ navLinks.forEach(link => link.addEventListener('click', () => {
   navList.classList.remove('open');
   navToggle.setAttribute('aria-expanded', 'false');
 }));
+
+const setActiveLink = () => {
+  let current = '';
+  sections.forEach(section => {
+    const sectionTop = section.offsetTop - 80;
+    if (window.scrollY >= sectionTop) {
+      current = section.getAttribute('id');
+    }
+  });
+  navLinks.forEach(link => {
+    const href = link.getAttribute('href').slice(1);
+    link.classList.toggle('active', href === current);
+  });
+};
+
+window.addEventListener('scroll', setActiveLink);
+setActiveLink();
 
 if (themeToggle) {
   const savedTheme = localStorage.getItem('theme');

--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,15 @@ a {
   transform: translateY(0);
 }
 
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
 .container {
   width: 90%;
   max-width: 1200px;
@@ -114,13 +123,31 @@ a {
 }
 
 #nav a {
+  position: relative;
   text-decoration: none;
   color: var(--text);
   transition: color 0.3s ease;
 }
 
-#nav a:hover {
+#nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+#nav a:hover,
+#nav a.active {
   color: var(--accent);
+}
+
+#nav a:hover::after,
+#nav a.active::after {
+  width: 100%;
 }
 
 .theme-switch {
@@ -179,13 +206,14 @@ input:checked + .slider:before {
   min-height: 100vh;
   display: flex;
   align-items: center;
-  background: var(--bg);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--bg) 100%);
   color: var(--text);
 }
 
 .hero .container {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 2rem;
 }
 
@@ -200,6 +228,7 @@ input:checked + .slider:before {
   background: url('https://images.unsplash.com/photo-1601040343084-a1f1d5e5c050?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
   border-radius: 12px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  animation: float 6s ease-in-out infinite;
 }
 
 .hero .btn {
@@ -210,11 +239,13 @@ input:checked + .slider:before {
   text-decoration: none;
   border-radius: 4px;
   display: inline-block;
-  transition: background 0.3s ease;
+  transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .hero .btn:hover {
   background: #00939c;
+  transform: translateY(-3px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .services {
@@ -237,7 +268,12 @@ input:checked + .slider:before {
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   color: var(--text);
-  transition: background-color 0.4s ease, color 0.4s ease;
+  transition: background-color 0.4s ease, color 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.service:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
 .projects {
@@ -259,7 +295,12 @@ input:checked + .slider:before {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   overflow: hidden;
   color: var(--text);
-  transition: background-color 0.4s ease, color 0.4s ease;
+  transition: background-color 0.4s ease, color 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.project-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
 .project-image {
@@ -315,11 +356,13 @@ input:checked + .slider:before {
   color: var(--bg);
   cursor: pointer;
   border-radius: 4px;
-  transition: background 0.3s ease, background-color 0.4s ease, color 0.4s ease;
+  transition: background 0.3s ease, background-color 0.4s ease, color 0.4s ease, transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .contact button:hover {
   background: #00939c;
+  transform: translateY(-3px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .contact-info {

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,22 @@
 :root {
+  --bg: #ffffff;
+  --text: #0a0a0a;
+  --accent: #00adb5;
+  --surface: #f5f5f5;
+  --card: #ffffff;
+  --header-bg: rgba(255, 255, 255, 0.9);
+  --border: #ccc;
+  --footer-bg: #f5f5f5;
+}
+
+[data-theme="dark"] {
   --bg: #0a0a0a;
   --text: #f5f5f5;
-  --accent: #00adb5;
+  --surface: #111;
+  --card: #1c1c1c;
+  --header-bg: rgba(10, 10, 10, 0.9);
+  --border: #333;
+  --footer-bg: #000;
 }
 
 * {
@@ -47,7 +62,7 @@ a {
   top: 0;
   left: 0;
   width: 100%;
-  background: rgba(10, 10, 10, 0.9);
+  background: var(--header-bg);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   z-index: 1000;
 }
@@ -78,7 +93,7 @@ a {
   position: absolute;
   top: 60px;
   right: 0;
-  background: #111;
+  background: var(--surface);
   list-style: none;
   display: flex;
   flex-direction: column;
@@ -104,6 +119,57 @@ a {
 
 #nav a:hover {
   color: var(--accent);
+}
+
+.theme-switch {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--border);
+  transition: 0.4s;
+  border-radius: 20px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background-color: #fff;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background: var(--accent);
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
 }
 
 .hero {
@@ -162,7 +228,7 @@ a {
 }
 
 .services {
-  background: #111;
+  background: var(--surface);
   padding: 4rem 0;
   text-align: center;
 }
@@ -175,7 +241,7 @@ a {
 }
 
 .service {
-  background: #1c1c1c;
+  background: var(--card);
   padding: 2rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
@@ -183,7 +249,7 @@ a {
 }
 
 .projects {
-  background: #111;
+  background: var(--surface);
   padding: 4rem 0;
 }
 
@@ -195,7 +261,7 @@ a {
 }
 
 .project-card {
-  background: #1c1c1c;
+  background: var(--card);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   overflow: hidden;
@@ -221,7 +287,7 @@ a {
 }
 
 .contact {
-  background: #111;
+  background: var(--surface);
   padding: 4rem 0;
   text-align: center;
 }
@@ -239,10 +305,10 @@ a {
 .contact input,
 .contact textarea {
   padding: 0.75rem;
-  border: 1px solid #333;
+  border: 1px solid var(--border);
   border-radius: 4px;
   width: 100%;
-  background: #1c1c1c;
+  background: var(--card);
   color: var(--text);
 }
 
@@ -265,7 +331,7 @@ a {
 }
 
 .site-footer {
-  background: #000;
+  background: var(--footer-bg);
   color: var(--text);
   text-align: center;
   padding: 1rem 0;

--- a/styles.css
+++ b/styles.css
@@ -1,119 +1,225 @@
+:root {
+  --primary: #0c3c60;
+  --dark: #222;
+  --light: #fff;
+}
+
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    line-height: 1.6;
-}
-
-header {
-    background: #333;
-    color: #fff;
-}
-
-header .container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem;
-}
-
-#nav ul {
-    list-style: none;
-    display: flex;
-    gap: 1rem;
-    margin: 0;
-    padding: 0;
-}
-
-#nav a {
-    color: #fff;
-    text-decoration: none;
-}
-
-#nav-toggle {
-    display: none;
-    background: none;
-    border: none;
-    color: #fff;
-    font-size: 1.5rem;
-    cursor: pointer;
-}
-
-.hero {
-    background: #f4f4f4;
-    text-align: center;
-    padding: 4rem 1rem;
-}
-
-section {
-    padding: 2rem 1rem;
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  color: var(--dark);
 }
 
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.site-header .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+.logo {
+  font-weight: bold;
+  color: var(--primary);
+  text-decoration: none;
+  font-size: 1.25rem;
+}
+
+#nav ul {
+  display: flex;
+  list-style: none;
+  gap: 2rem;
+}
+
+#nav a {
+  text-decoration: none;
+  color: var(--dark);
+}
+
+#nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.hero {
+  background: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: var(--light);
+}
+
+.hero .btn {
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--primary);
+  color: var(--light);
+  text-decoration: none;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.about .container {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  padding: 4rem 0;
+}
+
+.about-text {
+  flex: 1;
+}
+
+.about-image {
+  flex: 1;
+  min-height: 300px;
+  background: url('https://images.unsplash.com/photo-1601040343084-a1f1d5e5c050?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
+  border-radius: 8px;
+}
+
+.services {
+  background: #f7f7f7;
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.services .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.service {
+  background: var(--light);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.projects {
+  padding: 4rem 0;
 }
 
 .projects .grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
 }
 
-.card {
-    background: #fff;
-    padding: 1rem;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+.project-card {
+  background: var(--light);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
 }
 
-form {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+.project-image {
+  height: 180px;
+  background-size: cover;
+  background-position: center;
 }
 
-input, textarea {
-    padding: 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+.project1 {
+  background-image: url('https://images.unsplash.com/photo-1581091012184-7a4277f2c1b7?auto=format&fit=crop&w=1350&q=80');
 }
 
-button {
-    padding: 0.75rem;
-    border: none;
-    background: #333;
-    color: #fff;
-    cursor: pointer;
+.project2 {
+  background-image: url('https://images.unsplash.com/photo-1556155092-8707de31f9c4?auto=format&fit=crop&w=1350&q=80');
 }
 
-footer {
-    background: #333;
-    color: #fff;
-    text-align: center;
-    padding: 1rem;
+.project3 {
+  background-image: url('https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=1350&q=80');
+}
+
+.contact {
+  background: #f7f7f7;
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.contact form {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 500px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.contact input,
+.contact textarea {
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.contact button {
+  padding: 0.75rem;
+  background: var(--primary);
+  border: none;
+  color: var(--light);
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.site-footer {
+  background: var(--dark);
+  color: var(--light);
+  text-align: center;
+  padding: 1rem 0;
 }
 
 @media (max-width: 768px) {
-    #nav ul {
-        flex-direction: column;
-        display: none;
-        background: #333;
-        position: absolute;
-        top: 60px;
-        right: 10px;
-        width: 200px;
-        padding: 1rem;
-    }
+  #nav ul {
+    position: absolute;
+    top: 60px;
+    right: 0;
+    background: var(--light);
+    flex-direction: column;
+    width: 200px;
+    padding: 1rem;
+    display: none;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
 
-    #nav ul.open {
-        display: flex;
-    }
+  #nav ul.open {
+    display: flex;
+  }
 
-    #nav-toggle {
-        display: block;
-    }
+  #nav-toggle {
+    display: block;
+  }
+
+  .about .container {
+    flex-direction: column;
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -10,10 +10,25 @@
   padding: 0;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Poppins', sans-serif;
   line-height: 1.6;
   color: var(--dark);
+}
+
+.fade-up {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.fade-up.in-view {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .container {
@@ -189,6 +204,10 @@ body {
   color: var(--light);
   cursor: pointer;
   border-radius: 4px;
+}
+
+.contact-info {
+  margin-bottom: 1.5rem;
 }
 
 .site-footer {

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,7 @@ body {
   line-height: 1.6;
   background: var(--bg);
   color: var(--text);
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 a {
@@ -65,6 +66,7 @@ a {
   background: var(--header-bg);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   z-index: 1000;
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .site-header .container {
@@ -101,7 +103,7 @@ a {
   padding: 2rem;
   opacity: 0;
   transform: translateX(100%);
-  transition: transform 0.3s ease, opacity 0.3s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease, background-color 0.4s ease, color 0.4s ease;
   pointer-events: none;
 }
 
@@ -124,7 +126,8 @@ a {
 .theme-switch {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.5rem;
+  align-self: flex-start;
 }
 
 .switch {
@@ -231,6 +234,7 @@ input:checked + .slider:before {
   background: var(--surface);
   padding: 4rem 0;
   text-align: center;
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .services .grid {
@@ -246,11 +250,13 @@ input:checked + .slider:before {
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   color: var(--text);
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .projects {
   background: var(--surface);
   padding: 4rem 0;
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .projects .grid {
@@ -266,6 +272,7 @@ input:checked + .slider:before {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   overflow: hidden;
   color: var(--text);
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .project-image {
@@ -290,6 +297,7 @@ input:checked + .slider:before {
   background: var(--surface);
   padding: 4rem 0;
   text-align: center;
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .contact form {
@@ -310,6 +318,7 @@ input:checked + .slider:before {
   width: 100%;
   background: var(--card);
   color: var(--text);
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 .contact button {
@@ -319,7 +328,7 @@ input:checked + .slider:before {
   color: var(--bg);
   cursor: pointer;
   border-radius: 4px;
-  transition: background 0.3s ease;
+  transition: background 0.3s ease, background-color 0.4s ease, color 0.4s ease;
 }
 
 .contact button:hover {
@@ -335,6 +344,7 @@ input:checked + .slider:before {
   color: var(--text);
   text-align: center;
   padding: 1rem 0;
+  transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 @media (max-width: 768px) {

--- a/styles.css
+++ b/styles.css
@@ -175,26 +175,31 @@ input:checked + .slider:before {
   transform: translateX(20px);
 }
 
-.hero {
-  position: relative;
-  background: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
+ .hero {
   min-height: 100vh;
   display: flex;
   align-items: center;
-  text-align: center;
+  background: var(--bg);
   color: var(--text);
 }
 
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+.hero .container {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
 }
 
-.hero .container {
-  position: relative;
-  z-index: 1;
+.hero-text {
+  flex: 1;
+  text-align: left;
+}
+
+.hero-image {
+  flex: 1;
+  min-height: 400px;
+  background: url('https://images.unsplash.com/photo-1601040343084-a1f1d5e5c050?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
 }
 
 .hero .btn {
@@ -210,24 +215,6 @@ input:checked + .slider:before {
 
 .hero .btn:hover {
   background: #00939c;
-}
-
-.about .container {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-  padding: 4rem 0;
-}
-
-.about-text {
-  flex: 1;
-}
-
-.about-image {
-  flex: 1;
-  min-height: 300px;
-  background: url('https://images.unsplash.com/photo-1601040343084-a1f1d5e5c050?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
-  border-radius: 8px;
 }
 
 .services {
@@ -348,7 +335,12 @@ input:checked + .slider:before {
 }
 
 @media (max-width: 768px) {
-  .about .container {
-    flex-direction: column;
+  .hero .container {
+    flex-direction: column-reverse;
+    text-align: center;
+  }
+
+  .hero-text {
+    text-align: center;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,119 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    line-height: 1.6;
+}
+
+header {
+    background: #333;
+    color: #fff;
+}
+
+header .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+}
+
+#nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+#nav a {
+    color: #fff;
+    text-decoration: none;
+}
+
+#nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.hero {
+    background: #f4f4f4;
+    text-align: center;
+    padding: 4rem 1rem;
+}
+
+section {
+    padding: 2rem 1rem;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.projects .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background: #fff;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+input, textarea {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    padding: 0.75rem;
+    border: none;
+    background: #333;
+    color: #fff;
+    cursor: pointer;
+}
+
+footer {
+    background: #333;
+    color: #fff;
+    text-align: center;
+    padding: 1rem;
+}
+
+@media (max-width: 768px) {
+    #nav ul {
+        flex-direction: column;
+        display: none;
+        background: #333;
+        position: absolute;
+        top: 60px;
+        right: 10px;
+        width: 200px;
+        padding: 1rem;
+    }
+
+    #nav ul.open {
+        display: flex;
+    }
+
+    #nav-toggle {
+        display: block;
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 :root {
-  --primary: #0c3c60;
-  --dark: #222;
-  --light: #fff;
+  --bg: #0a0a0a;
+  --text: #f5f5f5;
+  --accent: #00adb5;
 }
 
 * {
@@ -17,7 +17,12 @@ html {
 body {
   font-family: 'Poppins', sans-serif;
   line-height: 1.6;
-  color: var(--dark);
+  background: var(--bg);
+  color: var(--text);
+}
+
+a {
+  color: var(--accent);
 }
 
 .fade-up {
@@ -42,8 +47,8 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: rgba(10, 10, 10, 0.9);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   z-index: 1000;
 }
 
@@ -56,47 +61,86 @@ body {
 
 .logo {
   font-weight: bold;
-  color: var(--primary);
+  color: var(--text);
   text-decoration: none;
   font-size: 1.25rem;
 }
 
-#nav ul {
-  display: flex;
-  list-style: none;
-  gap: 2rem;
-}
-
-#nav a {
-  text-decoration: none;
-  color: var(--dark);
-}
-
 #nav-toggle {
-  display: none;
   background: none;
   border: none;
   font-size: 1.5rem;
   cursor: pointer;
+  color: var(--text);
+}
+
+#nav ul {
+  position: absolute;
+  top: 60px;
+  right: 0;
+  background: #111;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  opacity: 0;
+  transform: translateX(100%);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  pointer-events: none;
+}
+
+#nav ul.open {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+#nav a {
+  text-decoration: none;
+  color: var(--text);
+  transition: color 0.3s ease;
+}
+
+#nav a:hover {
+  color: var(--accent);
 }
 
 .hero {
+  position: relative;
   background: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1350&q=80') center/cover no-repeat;
   min-height: 100vh;
   display: flex;
   align-items: center;
   text-align: center;
-  color: var(--light);
+  color: var(--text);
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.hero .container {
+  position: relative;
+  z-index: 1;
 }
 
 .hero .btn {
   margin-top: 1rem;
   padding: 0.75rem 1.5rem;
-  background: var(--primary);
-  color: var(--light);
+  background: var(--accent);
+  color: var(--bg);
   text-decoration: none;
   border-radius: 4px;
   display: inline-block;
+  transition: background 0.3s ease;
+}
+
+.hero .btn:hover {
+  background: #00939c;
 }
 
 .about .container {
@@ -118,7 +162,7 @@ body {
 }
 
 .services {
-  background: #f7f7f7;
+  background: #111;
   padding: 4rem 0;
   text-align: center;
 }
@@ -131,13 +175,15 @@ body {
 }
 
 .service {
-  background: var(--light);
+  background: #1c1c1c;
   padding: 2rem;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  color: var(--text);
 }
 
 .projects {
+  background: #111;
   padding: 4rem 0;
 }
 
@@ -149,10 +195,11 @@ body {
 }
 
 .project-card {
-  background: var(--light);
+  background: #1c1c1c;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   overflow: hidden;
+  color: var(--text);
 }
 
 .project-image {
@@ -174,7 +221,7 @@ body {
 }
 
 .contact {
-  background: #f7f7f7;
+  background: #111;
   padding: 4rem 0;
   text-align: center;
 }
@@ -192,18 +239,25 @@ body {
 .contact input,
 .contact textarea {
   padding: 0.75rem;
-  border: 1px solid #ccc;
+  border: 1px solid #333;
   border-radius: 4px;
   width: 100%;
+  background: #1c1c1c;
+  color: var(--text);
 }
 
 .contact button {
   padding: 0.75rem;
-  background: var(--primary);
+  background: var(--accent);
   border: none;
-  color: var(--light);
+  color: var(--bg);
   cursor: pointer;
   border-radius: 4px;
+  transition: background 0.3s ease;
+}
+
+.contact button:hover {
+  background: #00939c;
 }
 
 .contact-info {
@@ -211,33 +265,13 @@ body {
 }
 
 .site-footer {
-  background: var(--dark);
-  color: var(--light);
+  background: #000;
+  color: var(--text);
   text-align: center;
   padding: 1rem 0;
 }
 
 @media (max-width: 768px) {
-  #nav ul {
-    position: absolute;
-    top: 60px;
-    right: 0;
-    background: var(--light);
-    flex-direction: column;
-    width: 200px;
-    padding: 1rem;
-    display: none;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
-
-  #nav ul.open {
-    display: flex;
-  }
-
-  #nav-toggle {
-    display: block;
-  }
-
   .about .container {
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- add single-page portfolio site with about, project gallery, and contact sections
- style layout for desktop and mobile with flexbox, grid, and responsive navigation
- include small script for toggling mobile menu and update README
- improve navigation accessibility with `aria-expanded` and document deployment steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68904d41bdb4833191952525c05299d4